### PR TITLE
Add the ability to pass absolute paths in through the cli.

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -35,9 +35,11 @@ module.exports = (function() {
   proto.processFiles = function() {
     // files and paths as arrays
     this._files = this.options._;
-    this._paths = this._files.map(function(file) {
-      return path.join(process.cwd(), file);
-    });
+    this._paths = this.options.absolutePaths ?
+      this._files :
+      this._files.map(function(file) {
+        return path.join(process.cwd(), file);
+      });
 
     this.files = this.options.files = {};
     this.paths = this.options.paths = {};

--- a/lib/options.js
+++ b/lib/options.js
@@ -44,6 +44,13 @@ module.exports = optionator({
     type: 'Boolean',
     default: 'false',
     description: 'Use svn as source to generate diff.'
+  },
+  {
+    option: 'absolute-paths',
+    alias: 'a',
+    type: 'Boolean',
+    default: 'false',
+    description: 'Allow files to be passed in with absolute paths.'
   }
   // TODO:
   // {


### PR DESCRIPTION
Hello, thank you for all of your work on this excellent tool.

I've run into a use case where I would like to use css-ast-diff to process a large batch of diffs that may potentially span multiple drives (on windows).

This change would allow users to pass an "--absolute-paths" flag through the CLI and the filenames will not be rewritten relative to the current directory.

These changes seem to be working well for me, and I figured I would see if you would like to pull them in to the main project.