### PR TITLE
fixed version number of nodegit to avoid error on installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "es6-object-assign": "^1.0.3",
     "fs": "0.0.2",
     "node-diff": "^0.2.0",
-    "nodegit": "^0.11.8",
+    "nodegit": "0.18.0",
     "optionator": "^0.8.1",
     "path": "^0.12.7",
     "svn": "^0.2.0",


### PR DESCRIPTION
Currently when I try to install css-as-diff I get this error:

```
npm install css-ast-diff

> node lifecycleScripts/install

[nodegit] Fetching binary from S3.
[nodegit] Failed to install prebuilt binary:
{ Error: Command failed: /Users/cristianorastelli/Desktop/pippo/node_modules/nodegit/node_modules/.bin/node-pre-gyp install --fallback-to-build=false
node-pre-gyp ERR! install error
node-pre-gyp ERR! stack Error: 403 status code downloading tarball https://nodegit.s3.amazonaws.com/nodegit/nodegit/nodegit-v0.11.9-node-v48-darwin-x64.tar.gz
```

According to the status of nodegit their master is broken:
https://travis-ci.org/nodegit/nodegit/branches
and so the binary is not automatically uploaded on Amazon S3 (see this thread: https://github.com/nodegit/nodegit/issues/1046)

So I have fixed the version in package.json to the latest stable one (v0.18.0)